### PR TITLE
Fixing frame access time logic, also adding relative_time

### DIFF
--- a/pykinect2/PyKinectRuntime.py
+++ b/pykinect2/PyKinectRuntime.py
@@ -231,7 +231,7 @@ class PyKinectRuntime(object):
         with self._color_frame_lock:
             if self._color_frame_data is not None:
                 data = numpy.copy(numpy.ctypeslib.as_array(self._color_frame_data, shape=(self._color_frame_data_capacity.value,)))
-                _last_color_frame_access = time.clock()
+                self._last_color_frame_access = time.clock()
                 return data
             else:
                 return None
@@ -240,7 +240,7 @@ class PyKinectRuntime(object):
         with self._depth_frame_lock:
             if self._depth_frame_data is not None:
                 data = numpy.copy(numpy.ctypeslib.as_array(self._depth_frame_data, shape=(self._depth_frame_data_capacity.value,)))
-                _last_color_frame_access = time.clock()
+                self._last_color_frame_access = time.clock()
                 return data
             else:
                 return None
@@ -249,7 +249,7 @@ class PyKinectRuntime(object):
         with self._body_index_frame_lock:
             if self._body_index_frame_data is not None:
                 data = numpy.copy(numpy.ctypeslib.as_array(self._body_index_frame_data, shape=(self._body_index_frame_data_capacity.value,)))
-                _last_color_frame_access = time.clock()
+                self._last_color_frame_access = time.clock()
                 return data
             else:
                 return None
@@ -257,7 +257,7 @@ class PyKinectRuntime(object):
     def get_last_body_frame(self):
         with self._body_frame_lock:
             if self._body_frame_bodies is not None:
-                _last_body_frame_access = time.clock()
+                self._last_body_frame_access = time.clock()
                 return self._body_frame_bodies.copy()
             else:
                 return None

--- a/pykinect2/PyKinectRuntime.py
+++ b/pykinect2/PyKinectRuntime.py
@@ -433,6 +433,7 @@ class KinectBodyFrameData(object):
         self.floor_clip_plane = None
         if bodyFrame is not None:
             self.floor_clip_plane = bodyFrame.FloorClipPlane
+            self.relative_time = bodyFrame.RelativeTime
 
             self.bodies = numpy.ndarray((max_body_count), dtype=numpy.object)
             for i in range(0, max_body_count):
@@ -441,6 +442,7 @@ class KinectBodyFrameData(object):
     def copy(self):
         res = KinectBodyFrameData(None, None, 0)
         res.floor_clip_plane = self.floor_clip_plane
+        res.relative_time = self.relative_time
         res.bodies = numpy.copy(self.bodies)
         return res 
        


### PR DESCRIPTION
Hello,

Thank you for your work on this very useful project! It's a pleasure accessing the Kinect 2 from Python.

I'd like to submit this pull request, which makes the following additions:
1. Fixes frame access time logic
2. Addes a relative_time field to body frame data (which was previously inaccessible from the Python API).

As for the first point above, variables like `_last_body_frame_access` were used instead of `self._last_body_frame_access`, which caused functions such as `get_last_body_frame()` to always incorrectly return that there is new data (even if there isn't).

Thank you very much again!

All the best,
Steve