### PR TITLE
Added code to facilitate use with 32 and 64 bit numpy

### DIFF
--- a/pykinect2/PyKinectV2.py
+++ b/pykinect2/PyKinectV2.py
@@ -21,6 +21,9 @@ WSTRING = c_wchar_p
 from _ctypes import COMError
 comtypes.hresult.E_PENDING = 0x8000000A 
 
+import numpy.distutils.system_info as sysinfo
+
+
 class _event(object):
     """class used for adding/removing/invoking a set of listener functions"""
     __slots__ = ['handlers']
@@ -2213,7 +2216,9 @@ tagSTATSTG._fields_ = [
     ('grfStateBits', c_ulong),
     ('reserved', c_ulong),
 ]
-assert sizeof(tagSTATSTG) == 72, sizeof(tagSTATSTG)
+required_size = 64 + sysinfo.platform_bits / 4
+
+assert sizeof(tagSTATSTG) == required_size, sizeof(tagSTATSTG)
 assert alignment(tagSTATSTG) == 8, alignment(tagSTATSTG)
 IAudioBeamList._methods_ = [
     COMMETHOD(['propget'], HRESULT, 'BeamCount',


### PR DESCRIPTION
I use the numpy distutils module to determine whether the platform is 32 or 64 bit, then use that to adjust the value that sizeof(tagSTATSTG) is compared to.

EDIT: typos
